### PR TITLE
Added procedural download list and connection initialization with no security

### DIFF
--- a/server.py
+++ b/server.py
@@ -6,11 +6,13 @@ def accept_connection(sock):
     conn, addr = sock.accept()
     print(f"Accepting connection from {addr}")
     with conn:
+        conn.sendall(b'secure_code')
         while True:
             data = conn.recv(1024)
             if not data:
                 break
-            print(data)
+            if data == b'down_list':
+                conn.sendall(b'a.txt, b.mp4')
         conn.close()
 
 


### PR DESCRIPTION
Needs correct cybersecurity practices but works as a proof of concept at this point. When the peer starts up it sees if it can connect to the server which sends a verification message. When going to the downloads list, it asks the server for the information on the current available files, and then creates a checkmark list of these files which should eventually be able to click "download" on which will have the server send it into the correct peer-to-peer connection to get the files.